### PR TITLE
adding vm sku and displaying the contents of /var/crash to gsi-client.sh

### DIFF
--- a/tools/client/README.txt
+++ b/tools/client/README.txt
@@ -23,3 +23,10 @@ Tool for collecintg information from a non-k8s lustre clients
 * -h display help info
 *
 * Information is gathered into a tarball file in the format: client-gsi-YYYY-MM-DDTHH-MM-SS.tgz
+
+== aks-node-ssh.sh usage:
+
+Tool to allow ease of access when using ssh to connect to an aks/k8s node
+* Running the script will display a numbered list of the nodes - created from the output of kubectl get nodes
+* Enter the number next to the aks node to initiate an ssh session
+* Prompt reminds to enter "chroot /host /bin/bash" once connected to a node

--- a/tools/client/README.txt
+++ b/tools/client/README.txt
@@ -17,5 +17,9 @@ For info collection via debug daemon:
 
 == gsi-client.sh usage:
 
-Another tool for collecint information from a lustre client.
-* 
+Tool for collecintg information from a non-k8s lustre clients
+* gsi-client.sh (without arguments) gathers info from each lustre client the script is run on.
+* -l <log dir> defaults to "."
+* -h display help info
+*
+* Information is gathered into a tarball file in the format: client-gsi-YYYY-MM-DDTHH-MM-SS.tgz

--- a/tools/client/README.txt
+++ b/tools/client/README.txt
@@ -14,3 +14,8 @@ For info collection via debug daemon:
 * -Q <debug log file> stops debug daemon with debug log file previously set with -D
 * -M <debug mask> optional. examples: "+net", "-net", or "-1" for "start debug_daemon"
 * -Z <size> debug log file size, default to unlimited for "start debug_daemon"
+
+== gsi-client.sh usage:
+
+Another tool for collecint information from a lustre client.
+* 

--- a/tools/client/aks-node-ssh.sh
+++ b/tools/client/aks-node-ssh.sh
@@ -2,243 +2,50 @@
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
 #
-    
-usage() {
-    echo "Usage ${0##*/} [options]"
-    echo "collect lustre info"
-    echo "  -l <log dir> starting dir for client-gsi-<date/time> dir.  Default to $HOME"
-    echo "  -s Display hsm_state of all files.  May be very time consuming.  Skip is default."
-    echo "  -h help"
-    exit
-}
 
 main() {
     readarray -t nodes_array <<< "$(kubectl get nodes |grep -Ev ^NAME |awk '{print $1}')"
-    menu_number=1
-    # for aks_node_name in $(kubectl get nodes |grep -Ev ^NAME |awk '{print $1}')
-    # echo "${nodes_array[@]}"
-    for aks_node_name in "${nodes_array[@]}"
-    do
-        echo "$menu_number. $aks_node_name"
-        ((menu_number += 1))
-    done
-    ((menu_number-=1))
-    echo
-    read -p "Enter number next to node 1..$menu_number: " node_number
-    array_index=$((node_number - 1))
-    aks_node="${nodes_array[$array_index]}"
-    echo "$aks_node"
-    kubectl debug node/${aks_node} --image=ubuntu -it
-    exit
-    logdir=$HOME
-    while getopts "hl:s" arg; do
-        case $arg in
-            h)
-                usage
-                ;;
-            l)
-                logdir="$OPTARG"
-                ;;
-            s)
-                run_hsm_state=1
-                ;;
-            *)
-                exit
-                ;;
-        esac
-    done
-    
-    check_prerequisites # call subroutine to verify client can run the script
-    
-    clientgsidir="client-gsi-$(date +"%FT%T")"
-    echo "$clientgsidir"
-    cd "$logdir" || exit
-    mkdir "$clientgsidir"
-    cd "$clientgsidir" || exit
-    log="$logdir"/"$clientgsidir"/gsi_client.log
-    echo "$(date +"%FT%T"): Starting gsi_client.sh cpature." > "$log"
-    echo "$(date +"%FT%T"): client gsi dir: " "$clientgsidir" >> "$log"
-    command_divider "uname -a"
-    uname -a |tee uname_a >> "$log"
-    command_divider "cat /etc/os-release"
-    tee release  >> "$log" < /etc/os-release
-    command_divider "uptime; uptime -p"
-    uptime |tee uptime >> "$log"; uptime -p |tee -a uptime >> "$log"
-
-    find_vm_sku # call subroutine to find the azure sku for the vm
-    
-    command_divider "netstat -rn"
-    netstat -rn |tee netstat_rn >> "$log"
-    command_divider "netstat -Wan"
-    netstat -Wan > netstat_Wan
-    command_divider "ifconfig -a"
-    ifconfig -a 2>&1 |tee ifconfig_a >> "$log"
-    command_divider "printenv"
-    printenv |tee printenv >> "$log"
-    # lfs commands
-    command_divider "lfs --version"
-    lfs --version |tee lfs_version >> "$log"
-    command_divider "lfs df -h --lazy; lfs df -hi --lazy" # --lazy will allow command to run if an OST is having problems.
-    {
-    echo "lfs df -h (bytes)" | tee lfs_df
-    lfs df -h --lazy |tee -a lfs_df
-    echo "lfs df -hi (inodes)" |tee -a lfs_df
-    lfs df -hi --lazy |tee -a lfs_df
-     } >> "$log"
-    command_divider "lfs check all"
-    lfs check all 2>&1 |tee lfs_check_all >> "$log"
-    command_divider "lfs getname"
-    lfs getname 2>&1 |tee lfs_getname >> "$log"
-
-    get_logs # subroutine to get syslog or messages files
-
-    command_divider "sudo dmesg -T"
-    sudo dmesg -T |tee dmesg > /dev/null
-    command_divider "sudo sysctl -a"
-    sudo sysctl -a | tee sysctl > /dev/null
-    command_divider "sudo lnetctl stats show"
-    sudo lnetctl stats show |tee lnetctl_stats >> "$log"
-    command_divider "lctl ping nids"
-    for nid in $(sudo lctl list_nids)
-    do 
-        echo "nid: $nid" |tee lctl_ping_nids >> "$log"
-        sudo lctl ping "$nid" |tee -a lctl_ping_nids >> "$log"
-    done
-    command_divider "sudo lctl dl -t"
-    sudo lctl dl -t |tee lctl_dl >> "$log"
-    command_divider "mount |egrep lustre; mount"
-    mount |grep -E lustre |tee mount_output >> "$log"; mount >> mount_output
-    if [ -f /etc/fstab ]
+    if [ "${nodes_array[0]}" ]
     then
-        command_divider "cat /etc/fstab |egrep lustre; cat /etc/fstab"
-        grep -E lustre < /etc/fstab |tee fstab >> "$log"
-        tee -a fstab < /etc/fstab >> "$log"
-    else
-        command_divider "No /etc/fstab file."
-    fi
-    command_divider "sudo lctl dk dump_kernel"
-    sudo lctl dk dump_kernel |tee -a "$log" > /dev/null
-    sudo chmod 666 dump_kernel
-    command_divider "find /var/crash -ls"
-    find /var/crash -ls |tee var_crash >> "$log"
-
-    local_lustre_mounts=$(lfs getname |awk '{print $2}')
-    if [ "$local_lustre_mounts" ]
-    then
-        for read_ahead_kb in /sys/devices/virtual/bdi/lustrefs-*/read_ahead_kb
-        do
-            command_divider "cat $read_ahead_kb"
-            echo -n "$read_ahead_kb: " >> read_ahead_kb
-            tee -a read_ahead_kb < "$read_ahead_kb" >> "$log"
-        done
-        for local_lustre_mount in $local_lustre_mounts
-        do
-            command_divider "lfs quota -hv $local_lustre_mount"
-            lfs quota -hv "$local_lustre_mount" |tee -a lfs_quota >> "$log"
+        node_number=99
+        while [ "$node_number" -ne 0 ]; do
+            clear
+            menu_number=1
+            for aks_node_name in "${nodes_array[@]}"
+            do
+                echo "$menu_number. $aks_node_name"
+                ((menu_number += 1))
+            done
+            ((menu_number-=1))
+            echo
+            node_number=0
+            read -r -p "Enter number next to node 1..$menu_number - 0 (zero) to exit: " node_number
+            if [ -n "$node_number" ] && [ "$node_number" -eq "$node_number" ] 2>/dev/null
+            then
+                if [ "$node_number" -gt 0 ] 
+                then
+                    array_index=$((node_number - 1))
+                    if [ "${nodes_array[$array_index]}" ]
+                    then
+                        aks_node="${nodes_array[$array_index]}"
+                        echo "Once connected to node $aks_node enter chroot /host /bin/bash"
+                        kubectl debug node/"${aks_node}" --image=ubuntu -it
+                    fi
+                fi
+            else
+                # At this point the menu choice is not numeric.
+                # if the response starts with e (lower or upper case) it has the same effect as 0 (exit)
+                node_number="${node_number,,}" # converts to lower case
+                if [[ "$node_number" =~ ^e ]]
+                then
+                    node_number=0
+                else
+                    node_number=99
+                fi
+            fi
         done
     else
-        command_divider "Lustre/amlfs is not mounted by client!"
-    fi
-
-    if [ "$read_ahead_kb" ]
-    then
-        echo "Further analysis required if read_ahead_kb is > 0" >> "$log"
-    else
-        command_divider "client does not contain a value for lustrefs read_ahead_kb.  All good."
-    fi
-    if [ "$run_hsm_state" ]
-    then
-        display_hsm_state # call subroutine to display hsm_state of all files.  May be time consuming.
-    fi
-
-    sudo chmod 666 ./*
-    cd ..
-    gsi_compressed=$(echo "$clientgsidir".tgz |sed 's/:/-/g')
-    tar cvfz "$gsi_compressed" "$clientgsidir"/ >/dev/null
-}
-
-check_prerequisites() {
-    prerequisites_met=1
-    if [[ ! -d $logdir ]] || [[ ! -w $logdir ]]
-    then
-        >&2 echo "ERROR: log directory $logdir must exist and be writable"
-        prerequisites_met=0
-    fi
-    sudo_works=$(sudo -n uptime 2>&1 | grep -c "load")
-    if [ "$sudo_works" == 0 ]
-    then
-        >&2 echo "ERROR: sudo access is required to run gsi-client.sh"
-        prerequisites_met=0
-    fi
-    lfs_exists=$(which lfs)
-    lctl_exists=$(which lctl)
-    lnetctl_exists=$(which lnetctl)
-    if [ "$lfs_exists" ] || [ "$lctl_exists" ] || [ "$lnetctl_exists" ]
-    then
-        echo "Yes, Lustre client!"
-    else
-        echo "not a lustre client"
-        prerequisites_met=0
-    fi
-
-    if [ $prerequisites_met != 1 ]
-    then
-        exit
-    fi
-}
-
-find_vm_sku() {
-    zipfile=$(sudo ls /var/lib/waagent/history |grep -E zip |xargs -0 -n 1 --null echo |grep -E _1- |tail -1)
-    zipfile_with_path="/var/lib/waagent/history/$zipfile"
-    vm_sku=$(sudo unzip -p "$zipfile_with_path" |grep -E vmSize | sed 's/"vmSize"/\n"vmSize"/g' | grep '"vmSize"' | awk -F',' '{print $1}' |cut -d: -f2 |sed 's/\"//g')
-    command_divider "extracting vm sku from zip file in /var/lib/waagent/history.  Must access as root."
-    echo "$vm_sku" |tee vm_sku >> "$log"
-    vm_details=$(sudo unzip -p "$zipfile_with_path" |grep -E vmSize | sed 's/"vmSize"/\n"vmSize"/g' | grep '"vmSize"')
-    echo "$vm_details" |tee vm_details >> "$log"
-}
-
-command_divider() {
-    echo "$(date +"%FT%T"): "
-    echo "$(date +"%FT%T"): ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo "$(date +"%FT%T"): command: ${*}"
-    echo "$(date +"%FT%T"): "
-} >> "$log"
-
-get_logs() {
-    if [ -f /var/log/syslog ]
-    then
-        cd /var/log || exit
-        command_divider "cd /var/log; tail -30 syslog"
-        sudo tail -30 syslog |tee >> "$log"
-        command_divider "cd /var/log; tar cvfz $logdir/$clientgsidir/syslog.tgz syslog*"
-        sudo tar cvfz "$logdir"/"$clientgsidir"/syslog.tgz syslog* |tee -a "$log" > /dev/null
-        cd "$logdir"/"$clientgsidir" || exit
-    fi
-    if [ -f /var/log/messages ]
-    then
-        cd /var/log || exit
-        command_divider "cd /var/log; sudo tail -30 messages"
-        sudo tail -30 messages |tee >> "$log"
-        command_divider "cd /var/log; sudo tar cvfz $logdir/$clientgsidir/messages.tgz messages*"
-        sudo tar cvfz "$logdir"/"$clientgsidir"/messages.tgz messages* |tee -a "$log" > /dev/null
-        cd "$logdir"/"$clientgsidir" || exit
-    fi
-}
-
-display_hsm_state() {
-    if [ "$local_lustre_mounts" ]
-    then
-        for local_lustre_mount in $("$local_lustre_mounts")
-        do
-            command_divider "find $local_lustre_mount -type f -print0 |xargs -0 -n 1 lfs  hsm_state"
-            hsm_state_file=$(echo "hsm_state$local_lustre_mount" |sed 's/\//_/g')
-            echo "$local_lustre_mount" |tee "$hsm_state_file" >> "$log"
-            find "$local_lustre_mount" -type f -print0 |xargs -0 -n 1 lfs hsm_state >> "$hsm_state_file"
-            number_of_files=$(wc -l "$hsm_state_file")
-            echo "Number of files: $number_of_files" |tee -a "$hsm_state_file" >> "$log"
-        done
-    else
-        command_divider "Cannot find local lustre mount point.  Unable to display hsm_state."
+        echo "No nodes listed with kubectl get nodes command.  Consider re-running the aks-node-ssh.sh script."
     fi
 }
 main "$@"

--- a/tools/client/aks-node-ssh.sh
+++ b/tools/client/aks-node-ssh.sh
@@ -36,7 +36,10 @@ main() {
                     then
                         aks_node="${nodes_array[$array_index]}"
                         echo "Once connected to node $aks_node enter chroot /host /bin/bash"
-                        kubectl debug node/"${aks_node}" --image=ubuntu -it
+                        kubectl debug node/"${aks_node}" --image=ubuntu -it -- chroot /host /bin/bash
+                        # kubectl debug node/"${aks_node}" --image=ubuntu -it
+                        # Adding "-- chroot /host /bin/bash" to the kubectl command above 
+                        # so users to not have to enter it manually.  May need to remove this later.
                     fi
                 fi
             else

--- a/tools/client/aks-node-ssh.sh
+++ b/tools/client/aks-node-ssh.sh
@@ -36,7 +36,7 @@ main() {
                 # At this point the menu choice is not numeric.
                 # if the response starts with e (lower or upper case) it has the same effect as 0 (exit)
                 node_number="${node_number,,}" # converts to lower case
-                if [[ "$node_number" =~ ^e ]]
+                if [[ "$node_number" =~ ^e ]] || [[ "$node_number" =~ ^q ]]
                 then
                     node_number=0
                 else

--- a/tools/client/aks-node-ssh.sh
+++ b/tools/client/aks-node-ssh.sh
@@ -35,7 +35,7 @@ main() {
                     if [ "${nodes_array[$array_index]}" ]
                     then
                         aks_node="${nodes_array[$array_index]}"
-                        echo "Once connected to node $aks_node enter chroot /host /bin/bash"
+                        # echo "Once connected to node $aks_node enter chroot /host /bin/bash"
                         kubectl debug node/"${aks_node}" --image=ubuntu -it -- chroot /host /bin/bash
                         # kubectl debug node/"${aks_node}" --image=ubuntu -it
                         # Adding "-- chroot /host /bin/bash" to the kubectl command above 

--- a/tools/client/aks-node-ssh.sh
+++ b/tools/client/aks-node-ssh.sh
@@ -41,7 +41,7 @@ main() {
                 fi
             else
                 # At this point the menu choice is not numeric.
-                # if the response starts with e (lower or upper case) it has the same effect as 0 (exit)
+                # if the response starts with e or q (lower or upper case) it has the same effect as 0 (exit)
                 node_number="${node_number,,}" # converts to lower case
                 if [[ "$node_number" =~ ^e ]] || [[ "$node_number" =~ ^q ]]
                 then

--- a/tools/client/aks-node-ssh.sh
+++ b/tools/client/aks-node-ssh.sh
@@ -4,6 +4,13 @@
 #
 
 main() {
+    kubectl_exists=$(which kubectl)
+    if [ ! "$kubectl_exists" ]
+    then
+        echo "This tool requires the kubectl command.  Cannot find kubectl in path."
+        exit
+    fi
+
     readarray -t nodes_array <<< "$(kubectl get nodes |grep -Ev ^NAME |awk '{print $1}')"
     if [ "${nodes_array[0]}" ]
     then

--- a/tools/client/gsi-client.sh
+++ b/tools/client/gsi-client.sh
@@ -135,7 +135,7 @@ main() {
     else
         command_divider "Cannot find local lustre mount point.  Unable to display hsm_state."
     fi
-    sudo chmod 666 ./*glob*
+    sudo chmod 666 ./*
     cd ..
     gsi_compressed=$(echo "$clientgsidir".tgz |sed 's/:/-/g')
     tar cvfz "$gsi_compressed" "$clientgsidir"/ >/dev/null

--- a/tools/client/gsi-client.sh
+++ b/tools/client/gsi-client.sh
@@ -195,7 +195,6 @@ get_logs() {
         sudo tail -30 messages |tee >> "$log"
         command_divider "cd /var/log; sudo tar cvfz $logdir/$clientgsidir/messages.tgz messages*"
         sudo tar cvfz "$logdir"/"$clientgsidir"/messages.tgz messages* |tee -a "$log" > /dev/null
-        tar cvfz 
         cd "$logdir"/"$clientgsidir" || exit
     fi
 }

--- a/tools/client/gsi-client.sh
+++ b/tools/client/gsi-client.sh
@@ -54,7 +54,6 @@ main() {
     mkdir "$clientgsidir"
     cd "$clientgsidir" || exit
     log="$logdir"/"$clientgsidir"/gsi_client.log
-    echo "$log"
     echo "$(date +"%FT%T"): Starting gsi_client.sh cpature." > "$log"
     echo "$(date +"%FT%T"): client gsi dir: " "$clientgsidir" >> "$log"
     command_divider "uname -a"
@@ -125,7 +124,7 @@ main() {
         for local_lustre_mount in $(mount |grep -E "type lustre" |awk '{print $3}')
         do
             command_divider "find $local_lustre_mount -type f -print0 |xargs -0 -n 1 lfs  hsm_state"
-            hsm_state_file=$(echo "hsm_state $local_lustre_mount" |sed 's/\//_/g')
+            hsm_state_file=$(echo "hsm_state$local_lustre_mount" |sed 's/\//_/g')
             echo "$local_lustre_mount" |tee "$hsm_state_file" >> "$log"
             find "$local_lustre_mount" -type f -print0 |xargs -0 -n 1 lfs hsm_state >> "$hsm_state_file"
             number_of_files=$(wc -l "$hsm_state_file")

--- a/tools/client/gsi-client.sh
+++ b/tools/client/gsi-client.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+#
+# collect Lustre client info for troubleshooting.  As of 1/8/2024 commands run to collect logs:
+    # uname -a
+    # cat /etc/os-release
+    # uptime; uptime -p
+    # netstat -rn
+    # netstat -Wan
+    # ifconfig -a
+    # printenv
+    # lfs --version
+    # lfs df -h
+    # lfs check all
+    # cd /var/log; tail -30 syslog
+    # cd /var/log; tar cvfz /tmp/client-gsi-2024-01-08T18:52:21/syslog.tgz syslog*
+    # sudo dmesg -T
+    # sudo sysctl -a
+    # sudo lnetctl stats show
+    # sudo lctl dl -t
+    # mount |egrep lustre; mount
+    # cat /etc/fstab |egrep lustre; cat /etc/fstab
+    # cat /sys/devices/virtual/bdi/lustrefs-ffffa09f150c6800/read_ahead_kb
+    # find /lustre -type f -print0 |xargs -0 -n 1 lfs  hsm_state
+
+usage() {
+    less <<EOF
+Usage ${0##*/} [options]
+collect lustre info
+    -l <log dir> starting dir for client-gsi-<date/time> dir.  Default to $HOME
+    -h usage
+EOF
+    exit
+}
+
+main() {
+    logdir=$HOME
+    while getopts "hl:" arg; do
+        case $arg in
+            h)
+                usage
+                ;;
+            l)
+                logdir="$OPTARG"
+                ;;
+        esac
+    done
+    prerequisites_met=1
+    if [[ ! -d $logdir ]] || [[ ! -w $logdir ]]
+    then
+        >&2 echo "ERROR: log directory $logdir must exist and be writable"
+        prerequisites_met=0
+    fi
+    sudo_works=`sudo -n uptime 2>&1 | grep "load" | wc -l`
+    if [ $sudo_works == 0 ]
+    then
+        >&2 echo "ERROR: sudo access is required to run gsi-client.sh"
+        prerequisites_met=0
+    fi
+    lfs_exists=`which lfs`
+    lctl_exists=`which lctl`
+    lnetctl_exists=`which lnetctl`
+    # echo "lfs: " $lfs_exists "lctl: " $lctl_exists "lnetctl: " $lnetctl_exists
+    if ! ([ $lfs_exists ] || [ $lctl_exists ] || [ $lnetctl_exists ])
+    then
+        echo "not a lustre client"
+        prerequisites_met=0
+    else
+        echo "Yes, Lustre client!"
+    fi
+
+    if [ $prerequisites_met == 1 ]
+    then
+        clientgsidir="client-gsi-$(date +"%FT%T")"
+        echo $clientgsidir
+        cd $logdir
+        mkdir $clientgsidir
+        cd $clientgsidir
+        echo $(date +"%FT%T"): "Starting gsi_client.sh cpature." > gsi_client.log
+        echo $(date +"%FT%T"): "client gsi dir: " $clientgsidir >> gsi_client.log
+        command_divider "uname -a"
+        uname -a |tee uname_a >> gsi_client.log
+        command_divider "cat /etc/os-release"
+        cat /etc/os-release |tee os-release >> gsi_client.log
+        command_divider "uptime; uptime -p"
+        uptime |tee uptime >> gsi_client.log; uptime -p |tee -a uptime >> gsi_client.log
+        command_divider "netstat -rn"
+        netstat -rn |tee netstat_rn >> gsi_client.log
+        command_divider "netstat -Wan"
+        netstat -Wan > netstat_Wan
+        command_divider "ifconfig -a"
+        ifconfig -a 2>&1 |tee ifconfig_a >> gsi_client.log
+        command_divider "printenv"
+        printenv |tee printenv >> gsi_client.log
+
+        if [ -f /usr/bin/lfs ]
+        then
+            command_divider "lfs --version"
+            lfs --version |tee lfs_version >> gsi_client.log
+            command_divider "lfs df -h"
+            lfs df -h |tee lfs_df >> gsi_client.log
+            command_divider "lfs check all"
+            lfs check all 2>&1 |tee lfs_check_all >> gsi_client.log
+        fi
+        get_logs # subroutine to get syslog or messages files
+
+        command_divider "sudo dmesg -T"
+        sudo dmesg -T > dmesg
+        command_divider "sudo sysctl -a"
+        sudo sysctl -a > sysctl
+        command_divider "sudo lnetctl stats show"
+        sudo lnetctl stats show |tee lnetctl_stats >> gsi_client.log
+        command_divider "sudo lctl dl -t"
+        sudo lctl dl -t |tee lctl_dl >> gsi_client.log
+        command_divider "mount |egrep lustre; mount"
+        mount |egrep lustre |tee mount >> gsi_client.log; mount >> mount
+        if [ -f /etc/fstab ]
+        then
+            command_divider "cat /etc/fstab |egrep lustre; cat /etc/fstab"
+            cat /etc/fstab |egrep lustre |tee fstab >> gsi_client.log; cat /etc/fstab |tee -a fstab >> gsi_client.log
+        else
+            command_divider "No /etc/fstab file."
+        fi
+
+        local_lustre_mount=`mount |egrep "type lustre" |awk '{print $3}' |tail -1`
+        if [ $local_lustre_mount ]
+        then
+            for read_ahead_kb in `ls /sys/devices/virtual/bdi/lustrefs-*/read_ahead_kb`
+            do
+                    command_divider "cat $read_ahead_kb"
+                    echo -n "$read_ahead_kb: " >> read_ahead_kb
+                cat $read_ahead_kb |tee -a read_ahead_kb >> gsi_client.log
+            done
+        fi
+
+        if [ $read_ahead_kb ]
+        then
+            echo "Further analysis required if read_ahead_kb is > 0" >> gsi_client.log
+        else
+            command_divider "client does not contain a value for lustrefs read_ahead_kb.  All good."
+        fi
+
+        if [ $local_lustre_mount ]
+        then
+            for local_lustre_mount in `mount |egrep "type lustre" |awk '{print $3}'`
+            do
+                command_divider "find $local_lustre_mount -type f -print0 |xargs -0 -n 1 lfs  hsm_state"
+                hsm_state_file=`echo "hsm_state"$local_lustre_mount |sed 's/\//_/g'`
+                echo $local_lustre_mount |tee $hsm_state_file >> gsi_client.log
+                find $local_lustre_mount -type f -print0 |xargs -0 -n 1 lfs hsm_state >> $hsm_state_file
+                number_of_files=`wc -l $hsm_state_file`
+                echo "Number of files: $number_of_files" |tee -a $hsm_state_file >> gsi_client.log
+
+            done
+        else
+            command_divider "Cannot find local lustre mount point.  Unable to display hsm_state."
+        fi
+        sudo chmod 666 *
+        cd ..
+        gsi_compressed=`echo $clientgsidir.tgz |sed 's/:/-/g'`
+        tar cvfz $gsi_compressed $clientgsidir/ >/dev/null
+    fi
+}
+
+command_divider() {
+    echo $(date +"%FT%T"): " " >>  $logdir/$clientgsidir/gsi_client.log
+    echo $(date +"%FT%T"): "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" >>  $logdir/$clientgsidir/gsi_client.log
+    echo $(date +"%FT%T"): "command: ${*}" >>  $logdir/$clientgsidir/gsi_client.log
+    echo $(date +"%FT%T"): " " >>  $logdir/$clientgsidir/gsi_client.log
+}
+
+get_logs() {
+    if [ -f /var/log/syslog ]
+    then
+        cd /var/log
+        command_divider "cd /var/log; tail -30 syslog"
+        tail -30 syslog |tee >> $logdir/$clientgsidir/gsi_client.log
+        command_divider "cd /var/log; tar cvfz $logdir/$clientgsidir/syslog.tgz syslog*"
+        tar cvfz $logdir/$clientgsidir/syslog.tgz syslog* >> $logdir/$clientgsidir/gsi_client.log
+        cd $logdir/$clientgsidir
+    fi
+    if [ -f /var/log/messages ]
+    then
+        cd /var/log
+        command_divider "cd /var/log; sudo tail -30 messages"
+        sudo tail -30 messages |tee >> $logdir/$clientgsidir/gsi_client.log
+        command_divider "cd /var/log; sudo tar cvfz $logdir/$clientgsidir/messages.tgz messages*"
+        sudo tar cvfz $logdir/$clientgsidir/messages.tgz messages* >> $logdir/$clientgsidir/gsi_client.log
+        cd $logdir/$clientgsidir
+    fi
+}
+main "$@"
+exit

--- a/tools/client/gsi-client.sh
+++ b/tools/client/gsi-client.sh
@@ -25,12 +25,10 @@
     # find /lustre -type f -print0 |xargs -0 -n 1 lfs  hsm_state
 
 usage() {
-    less <<EOF
-Usage ${0##*/} [options]
-collect lustre info
-    -l <log dir> starting dir for client-gsi-<date/time> dir.  Default to $HOME
-    -h usage
-EOF
+    echo "Usage ${0##*/} [options]"
+    echo "collect lustre info"
+    echo "  -l <log dir> starting dir for client-gsi-<date/time> dir.  Default to $HOME"
+    echo "  -h help"
     exit
 }
 
@@ -44,150 +42,162 @@ main() {
             l)
                 logdir="$OPTARG"
                 ;;
+            *)
+                exit
+                ;;
         esac
     done
+    check_prerequisites # call subroutine to verify client can run the script
+    clientgsidir="client-gsi-$(date +"%FT%T")"
+    echo "$clientgsidir"
+    cd "$logdir" || exit
+    mkdir "$clientgsidir"
+    cd "$clientgsidir" || exit
+    log="$logdir"/"$clientgsidir"/gsi_client.log
+    echo "$log"
+    echo "$(date +"%FT%T"): Starting gsi_client.sh cpature." > "$log"
+    echo "$(date +"%FT%T"): client gsi dir: " "$clientgsidir" >> "$log"
+    command_divider "uname -a"
+    uname -a |tee uname_a >> "$log"
+    command_divider "cat /etc/os-release"
+    tee release  >> "$log" < /etc/os-release
+    command_divider "uptime; uptime -p"
+    uptime |tee uptime >> "$log"; uptime -p |tee -a uptime >> "$log"
+    command_divider "netstat -rn"
+    netstat -rn |tee netstat_rn >> "$log"
+    command_divider "netstat -Wan"
+    netstat -Wan > netstat_Wan
+    command_divider "ifconfig -a"
+    ifconfig -a 2>&1 |tee ifconfig_a >> "$log"
+    command_divider "printenv"
+    printenv |tee printenv >> "$log"
+
+    if [ -f /usr/bin/lfs ]
+    then
+        command_divider "lfs --version"
+        lfs --version |tee lfs_version >> "$log"
+        command_divider "lfs df -h"
+        lfs df -h |tee lfs_df >> "$log"
+        command_divider "lfs check all"
+        lfs check all 2>&1 |tee lfs_check_all >> "$log"
+    fi
+    get_logs # subroutine to get syslog or messages files
+
+    command_divider "sudo dmesg -T"
+    sudo dmesg -T |tee dmesg > /dev/null
+    command_divider "sudo sysctl -a"
+    sudo sysctl -a | tee sysctl > /dev/null
+    command_divider "sudo lnetctl stats show"
+    sudo lnetctl stats show |tee lnetctl_stats >> "$log"
+    command_divider "sudo lctl dl -t"
+    sudo lctl dl -t |tee lctl_dl >> "$log"
+    command_divider "mount |egrep lustre; mount"
+    mount |grep -E lustre |tee mount_output >> "$log"; mount >> mount_output
+    if [ -f /etc/fstab ]
+    then
+        command_divider "cat /etc/fstab |egrep lustre; cat /etc/fstab"
+        grep -E lustre < /etc/fstab |tee fstab >> "$log"
+        tee -a fstab < /etc/fstab >> "$log"
+    else
+        command_divider "No /etc/fstab file."
+    fi
+
+    local_lustre_mount=$(mount |grep -E "type lustre" |awk '{print $3}' |tail -1)
+    if [ "$local_lustre_mount" ]
+    then
+        for read_ahead_kb in /sys/devices/virtual/bdi/lustrefs-*/read_ahead_kb
+        do
+            command_divider "cat $read_ahead_kb"
+            echo -n "$read_ahead_kb: " >> read_ahead_kb
+            tee -a read_ahead_kb < "$read_ahead_kb" >> "$log"
+        done
+    fi
+
+    if [ "$read_ahead_kb" ]
+    then
+        echo "Further analysis required if read_ahead_kb is > 0" >> "$log"
+    else
+        command_divider "client does not contain a value for lustrefs read_ahead_kb.  All good."
+    fi
+
+    if [ "$local_lustre_mount" ]
+    then
+        for local_lustre_mount in $(mount |grep -E "type lustre" |awk '{print $3}')
+        do
+            command_divider "find $local_lustre_mount -type f -print0 |xargs -0 -n 1 lfs  hsm_state"
+            hsm_state_file=$(echo "hsm_state $local_lustre_mount" |sed 's/\//_/g')
+            echo "$local_lustre_mount" |tee "$hsm_state_file" >> "$log"
+            find "$local_lustre_mount" -type f -print0 |xargs -0 -n 1 lfs hsm_state >> "$hsm_state_file"
+            number_of_files=$(wc -l "$hsm_state_file")
+            echo "Number of files: $number_of_files" |tee -a "$hsm_state_file" >> "$log"
+
+        done
+    else
+        command_divider "Cannot find local lustre mount point.  Unable to display hsm_state."
+    fi
+    sudo chmod 666 ./*glob*
+    cd ..
+    gsi_compressed=$(echo "$clientgsidir".tgz |sed 's/:/-/g')
+    tar cvfz "$gsi_compressed" "$clientgsidir"/ >/dev/null
+}
+
+check_prerequisites() {
     prerequisites_met=1
     if [[ ! -d $logdir ]] || [[ ! -w $logdir ]]
     then
         >&2 echo "ERROR: log directory $logdir must exist and be writable"
         prerequisites_met=0
     fi
-    sudo_works=`sudo -n uptime 2>&1 | grep "load" | wc -l`
-    if [ $sudo_works == 0 ]
+    sudo_works=$(sudo -n uptime 2>&1 | grep -c "load")
+    if [ "$sudo_works" == 0 ]
     then
         >&2 echo "ERROR: sudo access is required to run gsi-client.sh"
         prerequisites_met=0
     fi
-    lfs_exists=`which lfs`
-    lctl_exists=`which lctl`
-    lnetctl_exists=`which lnetctl`
+    lfs_exists=$(which lfs)
+    lctl_exists=$(which lctl)
+    lnetctl_exists=$(which lnetctl)
     # echo "lfs: " $lfs_exists "lctl: " $lctl_exists "lnetctl: " $lnetctl_exists
-    if ! ([ $lfs_exists ] || [ $lctl_exists ] || [ $lnetctl_exists ])
+    if [ "$lfs_exists" ] || [ "$lctl_exists" ] || [ "$lnetctl_exists" ]
     then
+        echo "Yes, Lustre client!"
+    else
         echo "not a lustre client"
         prerequisites_met=0
-    else
-        echo "Yes, Lustre client!"
     fi
 
-    if [ $prerequisites_met == 1 ]
+    if [ $prerequisites_met != 1 ]
     then
-        clientgsidir="client-gsi-$(date +"%FT%T")"
-        echo $clientgsidir
-        cd $logdir
-        mkdir $clientgsidir
-        cd $clientgsidir
-        echo $(date +"%FT%T"): "Starting gsi_client.sh cpature." > gsi_client.log
-        echo $(date +"%FT%T"): "client gsi dir: " $clientgsidir >> gsi_client.log
-        command_divider "uname -a"
-        uname -a |tee uname_a >> gsi_client.log
-        command_divider "cat /etc/os-release"
-        cat /etc/os-release |tee os-release >> gsi_client.log
-        command_divider "uptime; uptime -p"
-        uptime |tee uptime >> gsi_client.log; uptime -p |tee -a uptime >> gsi_client.log
-        command_divider "netstat -rn"
-        netstat -rn |tee netstat_rn >> gsi_client.log
-        command_divider "netstat -Wan"
-        netstat -Wan > netstat_Wan
-        command_divider "ifconfig -a"
-        ifconfig -a 2>&1 |tee ifconfig_a >> gsi_client.log
-        command_divider "printenv"
-        printenv |tee printenv >> gsi_client.log
-
-        if [ -f /usr/bin/lfs ]
-        then
-            command_divider "lfs --version"
-            lfs --version |tee lfs_version >> gsi_client.log
-            command_divider "lfs df -h"
-            lfs df -h |tee lfs_df >> gsi_client.log
-            command_divider "lfs check all"
-            lfs check all 2>&1 |tee lfs_check_all >> gsi_client.log
-        fi
-        get_logs # subroutine to get syslog or messages files
-
-        command_divider "sudo dmesg -T"
-        sudo dmesg -T > dmesg
-        command_divider "sudo sysctl -a"
-        sudo sysctl -a > sysctl
-        command_divider "sudo lnetctl stats show"
-        sudo lnetctl stats show |tee lnetctl_stats >> gsi_client.log
-        command_divider "sudo lctl dl -t"
-        sudo lctl dl -t |tee lctl_dl >> gsi_client.log
-        command_divider "mount |egrep lustre; mount"
-        mount |egrep lustre |tee mount >> gsi_client.log; mount >> mount
-        if [ -f /etc/fstab ]
-        then
-            command_divider "cat /etc/fstab |egrep lustre; cat /etc/fstab"
-            cat /etc/fstab |egrep lustre |tee fstab >> gsi_client.log; cat /etc/fstab |tee -a fstab >> gsi_client.log
-        else
-            command_divider "No /etc/fstab file."
-        fi
-
-        local_lustre_mount=`mount |egrep "type lustre" |awk '{print $3}' |tail -1`
-        if [ $local_lustre_mount ]
-        then
-            for read_ahead_kb in `ls /sys/devices/virtual/bdi/lustrefs-*/read_ahead_kb`
-            do
-                    command_divider "cat $read_ahead_kb"
-                    echo -n "$read_ahead_kb: " >> read_ahead_kb
-                cat $read_ahead_kb |tee -a read_ahead_kb >> gsi_client.log
-            done
-        fi
-
-        if [ $read_ahead_kb ]
-        then
-            echo "Further analysis required if read_ahead_kb is > 0" >> gsi_client.log
-        else
-            command_divider "client does not contain a value for lustrefs read_ahead_kb.  All good."
-        fi
-
-        if [ $local_lustre_mount ]
-        then
-            for local_lustre_mount in `mount |egrep "type lustre" |awk '{print $3}'`
-            do
-                command_divider "find $local_lustre_mount -type f -print0 |xargs -0 -n 1 lfs  hsm_state"
-                hsm_state_file=`echo "hsm_state"$local_lustre_mount |sed 's/\//_/g'`
-                echo $local_lustre_mount |tee $hsm_state_file >> gsi_client.log
-                find $local_lustre_mount -type f -print0 |xargs -0 -n 1 lfs hsm_state >> $hsm_state_file
-                number_of_files=`wc -l $hsm_state_file`
-                echo "Number of files: $number_of_files" |tee -a $hsm_state_file >> gsi_client.log
-
-            done
-        else
-            command_divider "Cannot find local lustre mount point.  Unable to display hsm_state."
-        fi
-        sudo chmod 666 *
-        cd ..
-        gsi_compressed=`echo $clientgsidir.tgz |sed 's/:/-/g'`
-        tar cvfz $gsi_compressed $clientgsidir/ >/dev/null
+        exit
     fi
 }
 
 command_divider() {
-    echo $(date +"%FT%T"): " " >>  $logdir/$clientgsidir/gsi_client.log
-    echo $(date +"%FT%T"): "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" >>  $logdir/$clientgsidir/gsi_client.log
-    echo $(date +"%FT%T"): "command: ${*}" >>  $logdir/$clientgsidir/gsi_client.log
-    echo $(date +"%FT%T"): " " >>  $logdir/$clientgsidir/gsi_client.log
-}
+    echo "$(date +"%FT%T"): "
+    echo "$(date +"%FT%T"): ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "$(date +"%FT%T"): command: ${*}"
+    echo "$(date +"%FT%T"): "
+} >> "$log"
 
 get_logs() {
     if [ -f /var/log/syslog ]
     then
-        cd /var/log
+        cd /var/log || exit
         command_divider "cd /var/log; tail -30 syslog"
-        tail -30 syslog |tee >> $logdir/$clientgsidir/gsi_client.log
+        sudo tail -30 syslog |tee >> "$log"
         command_divider "cd /var/log; tar cvfz $logdir/$clientgsidir/syslog.tgz syslog*"
-        tar cvfz $logdir/$clientgsidir/syslog.tgz syslog* >> $logdir/$clientgsidir/gsi_client.log
-        cd $logdir/$clientgsidir
+        sudo tar cvfz "$logdir"/"$clientgsidir"/syslog.tgz syslog* |tee -a "$log" > /dev/null
+        cd "$logdir"/"$clientgsidir" || exit
     fi
     if [ -f /var/log/messages ]
     then
-        cd /var/log
+        cd /var/log || exit
         command_divider "cd /var/log; sudo tail -30 messages"
-        sudo tail -30 messages |tee >> $logdir/$clientgsidir/gsi_client.log
+        sudo tail -30 messages |tee >> "$log"
         command_divider "cd /var/log; sudo tar cvfz $logdir/$clientgsidir/messages.tgz messages*"
-        sudo tar cvfz $logdir/$clientgsidir/messages.tgz messages* >> $logdir/$clientgsidir/gsi_client.log
-        cd $logdir/$clientgsidir
+        sudo tar cvfz "$logdir"/"$clientgsidir"/messages.tgz messages* |tee -a "$log" > /dev/null
+        tar cvfz 
+        cd "$logdir"/"$clientgsidir" || exit
     fi
 }
 main "$@"


### PR DESCRIPTION
adding new features for ascertain the vm sku and display the contents of /var/crash.
Also, removed the output of lfs hsm_state from a default operation as it can take hours to complete on a production clusters.  
hsm_state can be captured manually or it can be added if the -s option is used on the command line.